### PR TITLE
Update writing-a-plugin.md

### DIFF
--- a/src/content/contribute/writing-a-plugin.md
+++ b/src/content/contribute/writing-a-plugin.md
@@ -183,7 +183,7 @@ module.exports = FileListPlugin;
 
 A plugin can be classified into types based on the event hooks it taps into. Every event hook is pre-defined as synchronous or asynchronous or waterfall or parallel hook and hook is called internally using call/callAsync method. The list of hooks that are supported or can be tapped into are generally specified in this.hooks property.
 
-For example:-
+For example:
 
 ```javascript
 this.hooks = {
@@ -193,7 +193,7 @@ this.hooks = {
 
 It represents that the only hook supported is `shouldEmit` which is a hook of `SyncBailHook` type and the only parameter which will be passed to any plugin that taps into `shouldEmit` hook is `compilation`.
 
-Various types of hooks supported are :-
+Various types of hooks supported are :
 
 ### Synchronous Hooks
 


### PR DESCRIPTION
Very small typo fixes. `s/:-/:/g` in writing-a-plugin.md
